### PR TITLE
feat: 向 AbstractEnchantment 类中 ActionText 两方法加入暗黑神话甲与"毒液"效果的判断

### DIFF
--- a/base/src/main/java/net/mizukilab/pit/enchantment/AbstractEnchantment.java
+++ b/base/src/main/java/net/mizukilab/pit/enchantment/AbstractEnchantment.java
@@ -11,6 +11,7 @@ import net.mizukilab.pit.enchantment.param.item.RodOnly;
 import net.mizukilab.pit.enchantment.param.item.WeaponOnly;
 import net.mizukilab.pit.enchantment.rarity.EnchantmentRarity;
 import net.mizukilab.pit.item.AbstractPitItem;
+import net.mizukilab.pit.util.PlayerUtil;
 import net.mizukilab.pit.util.PublicUtil;
 import net.mizukilab.pit.util.cooldown.Cooldown;
 import net.mizukilab.pit.util.time.TimeUtil;
@@ -42,20 +43,27 @@ public abstract class AbstractEnchantment {
     @Nullable
     public abstract Cooldown getCooldown();
     //填写此玩家触发附魔的所需冷却时间
-    public String getCooldownActionText(Cooldown cooldown) {
+    public String getCooldownActionText(Player player, Cooldown cooldown) {
+        if (PlayerUtil.isVenom(player) || PlayerUtil.isEquippingSomber(player)) { return "&c&l✘"; }
         return (cooldown.hasExpired() ? "&a&l✔" : "&c&l" + TimeUtil.millisToRoundedTime(cooldown.getRemaining()).replace(" ", ""));
     }
 
     //填写每x次攻击触发
     public String getHitActionText(Player player, int activeHit) {
-        int hit = (player.getItemInHand() != null && player.getItemInHand().getType() == Material.BOW ? PlayerProfile.getPlayerProfileByUuid(player.getUniqueId()).getBowHit() : PlayerProfile.getPlayerProfileByUuid(player.getUniqueId()).getMeleeHit());
+        if (PlayerUtil.isVenom(player) || PlayerUtil.isEquippingSomber(player)) { return "&c&l✘"; }
+
+        PlayerProfile pp = PlayerProfile.getRawCache(player.getUniqueId());
+        if (pp == null) { return "&c&l✘"; }
+
+        int hit = (player.getItemInHand() != null && player.getItemInHand().getType() == Material.BOW ? pp.getBowHit() : pp.getMeleeHit());
         return (hit % activeHit == 0 ? "&a&l✔" : "&e&l" + (activeHit - hit % activeHit));
     }
 
     //Todo: 需要一个判断玩家身上附魔是否生效中(持续时间内)的方法 (虽然也许不应该写在这里)
     public int getItemEnchantLevel(AbstractPitItem im) {
-        if (im == null)
+        if (im == null) {
             return -1;
+        }
         return im.getEnchantments().getInt(this);
     }
 
@@ -97,8 +105,12 @@ public abstract class AbstractEnchantment {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         AbstractEnchantment that = (AbstractEnchantment) o;
         return that.getNbtName().equals(this.getNbtName());
     }

--- a/core/src/main/java/net/mizukilab/pit/enchantment/type/dark_normal/SanguisugeEnchant.java
+++ b/core/src/main/java/net/mizukilab/pit/enchantment/type/dark_normal/SanguisugeEnchant.java
@@ -91,6 +91,6 @@ public class SanguisugeEnchant extends AbstractEnchantment implements IAttackEnt
 
     @Override
     public String getText(int level, Player player) {
-        return getCooldownActionText(cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
+        return getCooldownActionText(player, cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
     }
 }

--- a/core/src/main/java/net/mizukilab/pit/enchantment/type/normal/BooBooEnchant.java
+++ b/core/src/main/java/net/mizukilab/pit/enchantment/type/normal/BooBooEnchant.java
@@ -82,6 +82,6 @@ public class BooBooEnchant extends AbstractEnchantment implements ITickTask, IAc
 
     @Override
     public String getText(int level, Player player) {
-        return getCooldownActionText(cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
+        return getCooldownActionText(player, cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
     }
 }

--- a/core/src/main/java/net/mizukilab/pit/enchantment/type/normal/HappyNewYearEnchant.kt
+++ b/core/src/main/java/net/mizukilab/pit/enchantment/type/normal/HappyNewYearEnchant.kt
@@ -86,6 +86,6 @@ class HappyNewYearEnchant : AbstractEnchantment(), IPlayerDamaged, IActionDispla
     }
 
     override fun getText(level: Int, player: Player): String {
-        return getCooldownActionText(cooldown.getOrDefault(player.uniqueId, Cooldown(0)))
+        return getCooldownActionText(player, cooldown.getOrDefault(player.uniqueId, Cooldown(0)))
     }
 }

--- a/core/src/main/java/net/mizukilab/pit/enchantment/type/normal/PeroxideEnchant.java
+++ b/core/src/main/java/net/mizukilab/pit/enchantment/type/normal/PeroxideEnchant.java
@@ -95,6 +95,6 @@ public class PeroxideEnchant extends AbstractEnchantment implements IPlayerDamag
 
     @Override
     public String getText(int level, Player player) {
-        return getCooldownActionText(cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
+        return getCooldownActionText(player, cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
     }
 }

--- a/core/src/main/java/net/mizukilab/pit/enchantment/type/rage/BreachingChargeEnchant.kt
+++ b/core/src/main/java/net/mizukilab/pit/enchantment/type/rage/BreachingChargeEnchant.kt
@@ -90,7 +90,7 @@ class BreachingChargeEnchant : AbstractEnchantment(), Listener,IAttackEntity, IP
     }
 
     override fun getText(level: Int, player: Player): String {
-        return getCooldownActionText(Companion.cooldown.getOrDefault(player.uniqueId, Cooldown(0)))
+        return getCooldownActionText(player, Companion.cooldown.getOrDefault(player.uniqueId, Cooldown(0)))
     }
     @EventHandler
     fun quit(pq :PlayerQuitEvent){

--- a/core/src/main/java/net/mizukilab/pit/enchantment/type/rare/ComboComaEnchant.java
+++ b/core/src/main/java/net/mizukilab/pit/enchantment/type/rare/ComboComaEnchant.java
@@ -77,7 +77,7 @@ public class ComboComaEnchant extends AbstractEnchantment implements IAttackEnti
         byte b = 5;
         if ((Cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0L))).hasExpired())
             return (level % b == 0) ? "&a&l✔" : (new StringBuilder()).insert(0, "&e&l").append(b - level % b).toString();
-        return getCooldownActionText(Cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0L)));
+        return getCooldownActionText(player, Cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0L)));
     }
 
     @Override

--- a/core/src/main/java/net/mizukilab/pit/enchantment/type/rare/ComboStunEnchant.java
+++ b/core/src/main/java/net/mizukilab/pit/enchantment/type/rare/ComboStunEnchant.java
@@ -96,7 +96,7 @@ public class ComboStunEnchant extends AbstractEnchantment implements Listener, I
         if (cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)).hasExpired()) {
             return (hit % require == 0 ? "&a&l✔" : "&e&l" + (require - hit % require));
         } else {
-            return getCooldownActionText(cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
+            return getCooldownActionText(player, cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
         }
     }
 }

--- a/core/src/main/java/net/mizukilab/pit/enchantment/type/rare/FightOrDieEnchant.java
+++ b/core/src/main/java/net/mizukilab/pit/enchantment/type/rare/FightOrDieEnchant.java
@@ -81,6 +81,6 @@ public class FightOrDieEnchant extends AbstractEnchantment implements Listener, 
 
     @Override
     public String getText(int level, Player player) {
-        return getCooldownActionText(cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
+        return getCooldownActionText(player, cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
     }
 }

--- a/core/src/main/java/net/mizukilab/pit/enchantment/type/rare/HealerEnchant.kt
+++ b/core/src/main/java/net/mizukilab/pit/enchantment/type/rare/HealerEnchant.kt
@@ -63,7 +63,7 @@ class HealerEnchant : AbstractEnchantment(), Listener,IAttackEntity, IActionDisp
     }
 
     override fun getText(level: Int, player: Player): String {
-        return getCooldownActionText(Companion.cooldown.getOrDefault(player.uniqueId, Cooldown(0)))
+        return getCooldownActionText(player, Companion.cooldown.getOrDefault(player.uniqueId, Cooldown(0)))
     }
 
     override fun handleAttackEntity(

--- a/core/src/main/java/net/mizukilab/pit/enchantment/type/rare/ThePunchEnchant.java
+++ b/core/src/main/java/net/mizukilab/pit/enchantment/type/rare/ThePunchEnchant.java
@@ -100,6 +100,6 @@ public class ThePunchEnchant extends AbstractEnchantment implements Listener,IAt
 
     @Override
     public String getText(int level, Player player) {
-        return getCooldownActionText(cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
+        return getCooldownActionText(player, cooldown.getOrDefault(player.getUniqueId(), new Cooldown(0)));
     }
 }


### PR DESCRIPTION
#描述
在抽象类 AbstractEnchantment 中的 getCooldownActionText 与 getHitActionText 添加暗黑之甲的有关检测
同时将继承此抽象类的子类进行方法替换 