### PR TITLE
修复一个问题, 导致部分拥有旧插件数据的玩家在击杀时报错

### DIFF
--- a/core/src/main/java/net/mizukilab/pit/listener/CombatListener.java
+++ b/core/src/main/java/net/mizukilab/pit/listener/CombatListener.java
@@ -1241,7 +1241,7 @@ public class CombatListener implements Listener {
 //        }
         killerProfile.getUnlockedPerkMap().values().forEach(i -> {
             AbstractPerk abstractPerk = i.getHandle(perkFactory.getPerkMap());
-            if (!abstractPerk.isPassive()) {
+            if (abstractPerk == null || !abstractPerk.isPassive()) {
                 return;
             }
             if (abstractPerk instanceof IPlayerKilledEntity ins) {
@@ -1250,7 +1250,7 @@ public class CombatListener implements Listener {
         });
         killerProfile.getChosePerk().values().forEach(i -> {
             AbstractPerk abstractPerk = i.getHandle(perkFactory.getPerkMap());
-            if (abstractPerk.isPassive()) {
+            if (abstractPerk == null || abstractPerk.isPassive()) {
                 return;
             }
             if (abstractPerk instanceof IPlayerKilledEntity ins) {


### PR DESCRIPTION
在CombatListener.handleGameEffect内，检测技能的逻辑未添加null检查，导致拥有旧插件数据的玩家可能会获取到不存在的AbstractPerk导致报错
<img width="704" height="291" alt="f1b1d6aab90ee22313c1fe8a9f393be7" src="https://github.com/user-attachments/assets/f1da92e2-518a-4833-bff2-8ce81147efcf" />
